### PR TITLE
qcom: power: Allow devices to write their own platform specific bits

### DIFF
--- a/power/Android.mk
+++ b/power/Android.mk
@@ -16,6 +16,10 @@ LOCAL_PROPRIETARY_MODULE := true
 LOCAL_SHARED_LIBRARIES := liblog libcutils libdl
 LOCAL_SRC_FILES := power.c metadata-parser.c utils.c list.c hint-data.c
 
+ifneq ($(BOARD_POWER_CUSTOM_BOARD_LIB),)
+  LOCAL_WHOLE_STATIC_LIBRARIES += $(BOARD_POWER_CUSTOM_BOARD_LIB)
+else
+
 # Include target-specific files.
 ifeq ($(call is-board-platform-in-list, msm8974), true)
 LOCAL_SRC_FILES += power-8974.c
@@ -60,6 +64,8 @@ endif
 ifeq ($(call is-board-platform-in-list, msm8996), true)
 LOCAL_SRC_FILES += power-8996.c
 endif
+
+endif  #  End of board specific list
 
 ifneq ($(TARGET_POWERHAL_SET_INTERACTIVE_EXT),)
 LOCAL_CFLAGS += -DSET_INTERACTIVE_EXT


### PR DESCRIPTION
Using this hook, any device should be able to reuse the majority of the
powerhal and fork only power-<platform>.c if they feel that they need
the ability to provide more specific tuning of the hints/etc. for
their device.

Change-Id: I013a3ec3ddccbe6f74f3dacf456cc6e8b3ab3430